### PR TITLE
Allow for false and zero field values to be re-initialized correctly

### DIFF
--- a/src/FormController.js
+++ b/src/FormController.js
@@ -809,9 +809,10 @@ export class FormController {
     // Initialize value if needed
     // If we already have value i.e "saved"
     // use that ( it was not removed on purpose! )
+    // including false and 0 since they are values
     // Otherwise use the fields initial value
     if (
-      !this.getValue(name) &&
+      (this.getValue(name) == null || this.getValue(name) == undefined) &&
       meta.current.initialValue != null &&
       (meta.current.initializeValueIfPristine ? this.state.pristine : true)
     ) {


### PR DESCRIPTION
Allow for falsy values such as `false` and `0` to be re-initialized properly without reverting back to the initial value if they are `false` or `0` 