### PR TITLE
Added type for Debug props

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -513,7 +513,11 @@ declare namespace utils {
 }
 
 export function SchemaFields(): JSX.Element;
-export function Debug(): JSX.Element;
+
+type DebugProps = {
+  [FormStateKey in keyof FormState]?: boolean;
+};
+export function Debug(props: DebugProps): JSX.Element;
 
 // export class Elon {
 //   static inspect([any]): any;


### PR DESCRIPTION
I'm new to Informed so I didn't know I could specify a key of FormState with the Debug component. This would make this capability easily discoverable for TS devs. 