### PR TITLE
Update References from Twitter to X

### DIFF
--- a/vitedocs/Pages/Examples/ElonMusk/Example.jsx
+++ b/vitedocs/Pages/Examples/ElonMusk/Example.jsx
@@ -30,9 +30,9 @@ const Example = () => (
     {/* ------------- Formated inputs -------------- */}
     <Input name="worth" label="Worth" formatter={formatter} parser={parser} />
     {/* ------------- Relevance & Scoping ---------- */}
-    <Scope scope="twitter">
-      <Checkbox name="love" label="Do you love Twitter?" />
-      <Relevant when={({ formState }) => formState.values.twitter?.love}>
+    <Scope scope="x">
+      <Checkbox name="love" label="Do you love X?" />
+      <Relevant when={({ formState }) => formState.values.x?.love}>
         <Input name="howMuch" label="How Much?" defaultValue="A LOT!" />
       </Relevant>
     </Scope>


### PR DESCRIPTION
## Summary:

- In light of Twitter's rebranding to X, this PR updates the only reference of "Twitter" to "X". 

## Changes:

- Updated example code block to replace "Twitter" references with "X"

## Testing:

- [x] Ensure existing jest suite passes