### PR TITLE
Allow for false or zero values to be remembered

### DIFF
--- a/src/FormController.js
+++ b/src/FormController.js
@@ -819,7 +819,7 @@ export class FormController {
       if (meta.remember) {
         const valueToRemember = this.getValue(name);
         // Only remember if there is something to remember ( that way we dont wipe previous memory )
-        if (valueToRemember) {
+        if (valueToRemember != undefined) {
           debug('Remembering', name, valueToRemember);
           ObjectMap.set(this.state.memory, name, valueToRemember);
         }


### PR DESCRIPTION
Allow for falsy values such as false and 0 to be remembered properly if they are `false` or `0`