### PR TITLE
Fix ArrayField initialValue type to accept arrays

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -449,7 +449,7 @@ declare function ArrayField({
 }: {
   children: (arrayFieldApi: ArrayFieldApi & ArrayFieldState) => JSX.Element;
   name: string;
-  initialValue?: [unknown];
+  initialValue?: unknown[];
   arrayFieldApiRef?: React.MutableRefObject<any>;
 }): JSX.Element;
 

--- a/index.test-d.tsx
+++ b/index.test-d.tsx
@@ -17,7 +17,13 @@ import {
   FormProvider,
 } from '.';
 
-import {expectType} from 'tsd';
+import { expectError, expectType } from 'tsd';
+
+expectError(
+  <ArrayField name="friendsInvalid" initialValue={{ name: 'Nope' }}>
+    {() => <></>}
+  </ArrayField>
+);
 
 
 type FormProps = React.FormHTMLAttributes<HTMLFormElement>;
@@ -357,7 +363,13 @@ const ComponentUsingOtherShit = () => {
         }
       </FormStateAccessor>
       {/* ---------- Array Field ---------- */}
-      <ArrayField name="friends" initialValue={[{ name: 'Joe', age: 29}]} arrayFieldApiRef={arrayFieldApiRef}>
+      <ArrayField
+        name="friends"
+        initialValue={[
+          { name: 'Joe', age: 29 },
+          { name: 'Sue', age: 31 }
+        ]}
+        arrayFieldApiRef={arrayFieldApiRef}>
           {({ add }) => {
             return (
               <>
@@ -384,6 +396,10 @@ const ComponentUsingOtherShit = () => {
             );
           }}
         </ArrayField>
+      <ArrayField name="friendsSingle" initialValue={[{ name: 'Solo', age: 45 }]}>
+        {() => <></>}
+      </ArrayField>
+      <ArrayField name="friendsNoInitial">{() => <></>}</ArrayField>
     </>
   );
 };


### PR DESCRIPTION
## Summary
- widen `ArrayField.initialValue` to `unknown[]` so multi-item inits match runtime behavior
- add regression test coverage showing valid multi-item arrays, single-item arrays, and omission continue to type-check while non-arrays error

## Testing
- Not run (not requested)